### PR TITLE
Determine appropriate destination subnets for Infoblox integration

### DIFF
--- a/Automate/RedHatConsulting_Utilities/Service/Provisioning/DynamicDialogs.class/__methods__/get_templates_based_on_selected_os_and_location.rb
+++ b/Automate/RedHatConsulting_Utilities/Service/Provisioning/DynamicDialogs.class/__methods__/get_templates_based_on_selected_os_and_location.rb
@@ -7,11 +7,12 @@
 #
 @DEBUG = false
 
-OS_TAG_DIALOG_OPTION         = 'dialog_os_tag'
-LOCATION_TAGS_DIALOG_OPTION  = 'dialog_location_tags'
+OS_TAG_DIALOG_OPTION          = 'dialog_os_tag'
+LOCATION_TAGS_DIALOG_OPTION   = 'dialog_location_tags'
 
-PROVISIONING_LAN_TAG_CATEGORY = 'network_purpose'
+PROVISIONING_LAN_TAG_CATEGORY = 'lan_purpose'
 PROVISIONING_LAN_TAG_NAME     = 'provisioning'
+DESTINATION_LAN_TAG_NAME      = 'destination'
 
 require 'yaml'
 
@@ -49,7 +50,7 @@ begin
   
   # If there isn't a vmdb_object_type yet just exit. The method will be recalled with an vmdb_object_type
   exit MIQ_OK unless $evm.root['vmdb_object_type']
-  
+
   # get parameters
   os_tag         = $evm.root[OS_TAG_DIALOG_OPTION]
   location_tags  = $evm.root[LOCATION_TAGS_DIALOG_OPTION] || []
@@ -58,19 +59,25 @@ begin
   
   invalid_selection = false
   value = []
-  
+
   # invalid if expected provision lan tag category does not exist
   if !$evm.execute('category_exists?', PROVISIONING_LAN_TAG_CATEGORY)
     invalid_selection = true
     value << "Expected provisioning LAN Tag Category <#{PROVISIONING_LAN_TAG_CATEGORY}> does not exist."
   end
-    
+
   # invalid if expected provision lan tag does not exist
   if !$evm.execute('tag_exists?', PROVISIONING_LAN_TAG_CATEGORY, PROVISIONING_LAN_TAG_NAME)
     invalid_selection = true
     value << "Expected provisioning LAN Tag <#{PROVISIONING_LAN_TAG_NAME}> in Tag Category <#{PROVISIONING_LAN_TAG_CATEGORY}> does not exist."
   end
-  
+
+  # invalid if expected destination lan tag does not exist
+  if !$evm.execute('tag_exists?', PROVISIONING_LAN_TAG_CATEGORY, DESTINATION_LAN_TAG_NAME)
+    invalid_selection = true
+    value << "Expected destination LAN Tag <#{DESTINATION_LAN_TAG_NAME}> in Tag Category <#{PROVISIONING_LAN_TAG_CATEGORY}> does not exist."
+  end
+
   # invalid if no os template tag(s) selected
   if os_tag.blank?
     invalid_selection = true
@@ -87,6 +94,8 @@ begin
   # find appropriatlly tagged providers
   providers_by_tag              = {}
   provisioning_lans_by_provider = {}
+  destination_lans_by_provider = {}
+
   location_tags.each do |provider_tag_name|
     provider_tag_path = "/managed/#{provider_tag_name}"
     $evm.log(:info, "provider_tag_path => #{provider_tag_path}") if @DEBUG
@@ -102,21 +111,29 @@ begin
       # also determine the viable provisioning LANs
       host_messages = []
       tagged_providers.select! do |tagged_provider|
-        select = true
+        valid_provisioning_lans = true
+        valid_destination_lans = true
         
         # ensure that each host has at at least one provisioning LAN
         all_host_provisoning_lans = []
+        all_host_destination_lans = []
         tagged_provider.hosts.each do |host|
           
-          # find all the host provisioning LANs
+          # find all the host provisioning and destination LANs
+          # a provisioning lan will be selected here and the destination lans will go into a dropdown
           host_provisioning_lans = []
+          host_destination_lans = []
+
           host.lans.each do |lan|
             host_provisioning_lans << lan if lan.tagged_with?(PROVISIONING_LAN_TAG_CATEGORY, PROVISIONING_LAN_TAG_NAME)
+            host_destination_lans << lan if lan.tagged_with?(PROVISIONING_LAN_TAG_CATEGORY, DESTINATION_LAN_TAG_NAME)
           end
           
-          # invalid tagged provider if there is a single host without a provisioning tagged LAN
-          select = !host_provisioning_lans.empty?
-          if !select
+          # invalid tagged provider if there is a single host without tagged LANs
+          valid_provisioning_lans = !host_provisioning_lans.empty?
+          valid_destination_lans = !host_destination_lans.empty?
+
+          if !valid_provisioning_lans
             tag = $evm.vmdb(:classification).find_by_name("#{PROVISIONING_LAN_TAG_CATEGORY}/#{PROVISIONING_LAN_TAG_NAME}")
             message = "Provider <#{tagged_provider.name}> invalid because Host <#{host.name}> does not have a LAN with " +
                       "Tag <#{tag ? tag.parent.description : PROVISIONING_LAN_TAG_CATEGORY}: #{tag ? tag.description : PROVISIONING_LAN_TAG_NAME}>"
@@ -124,32 +141,51 @@ begin
             host_messages << message
           end
           
+          if !valid_destination_lans
+            tag = $evm.vmdb(:classification).find_by_name("#{PROVISIONING_LAN_TAG_CATEGORY}/#{DESTINATION_LAN_TAG_NAME}")
+            message = "Provider <#{tagged_provider.name}> invalid because Host <#{host.name}> does not have a LAN with " +
+                      "Tag <#{tag ? tag.parent.description : PROVISIONING_LAN_TAG_CATEGORY}: #{tag ? tag.description : DESTINATION_LAN_TAG_NAME}>"
+            $evm.log(:warn, message)
+            host_messages << message
+          end
+
+          all_host_destination_lans << host_destination_lans.collect { |lan| lan.name }
           all_host_provisoning_lans << host_provisioning_lans.collect { |lan| lan.name }
         end
         $evm.log(:info, "all_host_provisoning_lans => #{all_host_provisoning_lans}") if @DEBUG
+        $evm.log(:info, "all_host_destination_lans => #{all_host_destination_lans}") if @DEBUG
+
         
         # ensure there is a provisioning LAN that is tagged on all of the hosts on the provider 
         # `inject(:&) does an `&` opertion on all elements of the array, thus doing an intersection
         intersection_of_host_provisioning_lans = all_host_provisoning_lans.inject(:&)
+        intersection_of_host_destination_lans = all_host_destination_lans.inject(:&)
+
         $evm.log(:info, "intersection_of_host_provisioning_lans => #{intersection_of_host_provisioning_lans}") if @DEBUG
-        
+        $evm.log(:info, "intersection_of_host_destination_lans => #{intersection_of_host_destination_lans}") if @DEBUG
+
         # determine whether this provider should be selected if there is at least one provisioning LAN shared by all hosts on the provider
-        select = !intersection_of_host_provisioning_lans.empty?
-        
-        # save the viable provisoning LANs
+        valid_provisioning_lans = !intersection_of_host_provisioning_lans.empty?
+        valid_destination_lans = !intersection_of_host_destination_lans.empty?
+
+        # save the viable LANs
         provisioning_lans_by_provider[tagged_provider.name] = intersection_of_host_provisioning_lans
-        
+        destination_lans_by_provider[tagged_provider.name] = intersection_of_host_destination_lans
+
         # return whether to select this provider or not
-        select
+        select = valid_provisioning_lans and valid_destination_lans
       end
       
       # determine if found any tagged providers with required provisioning LAN
       if tagged_providers.empty?
         invalid_selection = true
-        provider_tag = $evm.vmdb(:classification).find_by_name(provider_tag_name)
-        lan_tag      = $evm.vmdb(:classification).find_by_name("#{PROVISIONING_LAN_TAG_CATEGORY}/#{PROVISIONING_LAN_TAG_NAME}")
+        provider_tag              = $evm.vmdb(:classification).find_by_name(provider_tag_name)
+        provisioning_lan_tag      = $evm.vmdb(:classification).find_by_name("#{PROVISIONING_LAN_TAG_CATEGORY}/#{PROVISIONING_LAN_TAG_NAME}")
+        destination_lan_tag       = $evm.vmdb(:classification).find_by_name("#{PROVISIONING_LAN_TAG_CATEGORY}/#{DESTINATION_LAN_TAG_NAME}")
+
         value << "Could not find Provider with Tag <#{provider_tag.parent.description}: #{provider_tag.description}> and with a " +
-                 "LAN with Tag <#{lan_tag ? lan_tag.parent.description : PROVISIONING_LAN_TAG_CATEGORY}: #{lan_tag ? lan_tag.description : PROVISIONING_LAN_TAG_NAME}>" +
+                 "LAN with both <#{provisioning_lan_tag ? provisioning_lan_tag.parent.description : PROVISIONING_LAN_TAG_CATEGORY}: #{provisioning_lan_tag ? provisioning_lan_tag.description : PROVISIONING_LAN_TAG_NAME}>" +
+                 "and <#{destination_lan_tag ? destination_lan_tag.parent.description : PROVISIONING_LAN_TAG_CATEGORY}: #{destination_lan_tag ? destination_lan_tag.description : DESTINATION_LAN_TAG_NAME}>" +
                  "on all hosts on the tagged provider."
         value.concat(host_messages)
       end
@@ -159,6 +195,8 @@ begin
   end
   $evm.log(:info, "providers_by_tag              => #{providers_by_tag}")              if @DEBUG
   $evm.log(:info, "provisioning_lans_by_provider => #{provisioning_lans_by_provider}") if @DEBUG
+  $evm.log(:info, "destination_lans_by_provider => #{destination_lans_by_provider}") if @DEBUG
+
   
   if !invalid_selection
     # ensure there are templates tagged with the correct OS
@@ -212,6 +250,7 @@ begin
     selected_templates.each do |selected_template|
       # NOTE: just choose the first valid provisioning LAN and warn there was more then one valid selection
       provisioning_lans = provisioning_lans_by_provider[selected_template.ext_management_system.name]
+      destination_lans = destination_lans_by_provider[selected_template.ext_management_system.name]
       provisioning_lan  = provisioning_lans.first
       $evm.log(:warn, "More then one valid provisioning LAN available with Tag <#{}: #{}> " +
                       " on Provider with Tag <#{}: #{}>") if provisioning_lans.length > 1
@@ -221,7 +260,8 @@ begin
         :provider         => selected_template.ext_management_system.name,
         :name             => selected_template.name,
         :guid             => selected_template.guid,
-        :provisioning_lan => provisioning_lan
+        :provisioning_lan => provisioning_lan,
+        :destination_lans => destination_lans
       }
     end
     value = value.to_yaml

--- a/Automate/RedHatConsulting_Utilities/Service/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
+++ b/Automate/RedHatConsulting_Utilities/Service/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
@@ -1,0 +1,48 @@
+#
+# Description: This method checks to see if the service has been provisioned
+#
+@DEBUG = false
+
+$evm.log("info", "Listing Root Object Attributes:")
+$evm.root.attributes.sort.each { |k, v| $evm.log("info", "\t#{k}: #{v}") }
+$evm.log("info", "===========================================")
+
+# Get current provisioning status
+task        = $evm.root['service_template_provision_task']
+task_status = task['status']
+result      = task.statemachine_task_status
+
+$evm.log('info', "Service Provision Check returned <#{result}> for state <#{task.state}> and status <#{task_status}>")
+
+if result == 'ok' || result == 'retry'
+  if task.miq_request_tasks.any? { |t| t.state != 'finished' }
+    result = 'retry'
+    $evm.log('info', "Child tasks not finished. Setting retry for task: #{task.id} ")
+  end
+  
+  # check for any provision requests set and wait for those to finish
+  provision_request_ids = task.get_option(:provision_request_ids) || {}
+  provision_request_ids = provision_request_ids.values
+  $evm.log(:info, "provision_request_ids => #{provision_request_ids}") if @DEBUG
+  if provision_request_ids.any? { |provision_request_id| $evm.vmdb('miq_request').find_by_id(provision_request_id).state != 'finished' }
+    result = 'retry'
+    $evm.log('info', "Child provision requests not finished. Setting restult <#{result}> for task: #{task.id} ")
+  else
+    result = 'ok'
+    $evm.log('info', "Child provision requests finished. Setting result <#{result}> for task: #{task.id} ")
+  end
+end
+
+case result
+when 'error'
+  $evm.root['ae_result'] = 'error'
+  reason = $evm.root['service_template_provision_task'].message
+  reason = reason[7..-1] if reason[0..6] == 'Error: '
+  $evm.root['ae_reason'] = reason
+when 'retry'
+  $evm.root['ae_result']         = 'retry'
+  $evm.root['ae_retry_interval'] = '1.minute'
+when 'ok'
+  # Bump State
+  $evm.root['ae_result'] = 'ok'
+end

--- a/Automate/RedHatConsulting_Utilities/Service/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.yaml
+++ b/Automate/RedHatConsulting_Utilities/Service/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: check_provisioned
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/Automate/RedHatConsulting_Utilities/Service/Provisioning/StateMachines/Methods.class/__methods__/create_provision_requests.rb
+++ b/Automate/RedHatConsulting_Utilities/Service/Provisioning/StateMachines/Methods.class/__methods__/create_provision_requests.rb
@@ -1,0 +1,225 @@
+# Uses `$evm.execute('create_provision_request', ..)` to create new VMs using the given information.
+# 
+# @param parsed_dialog_options    String (YAML) Parsed dialog options
+# @param parsed_dialog_tags       String (YAML) Parsed dialog tags
+# @param custom_vm_fields         Hash          Additional custom VM fields. See $evm.execute('create_provision_request')
+# @param custom_additional_values Hash          Additional custom additional (ws) fields. See $evm.execute('create_provision_request')
+@DEBUG = false
+
+def dump_object(object_string, object)
+  $evm.log("info", "Listing #{object_string} Attributes:") 
+  object.attributes.sort.each { |k, v| $evm.log("info", "\t#{k}: #{v}") }
+  $evm.log("info", "===========================================") 
+end
+
+def dump_current
+  $evm.log("info", "Listing Current Object Attributes:") 
+  $evm.current.attributes.sort.each { |k, v| $evm.log("info", "\t#{k}: #{v}") }
+  $evm.log("info", "===========================================") 
+end
+
+def dump_root
+  $evm.log("info", "Listing Root Object Attributes:") 
+  $evm.root.attributes.sort.each { |k, v| $evm.log("info", "\t#{k}: #{v}") }
+  $evm.log("info", "===========================================") 
+end
+
+def error(msg)
+  $evm.root['ae_result'] = 'error'
+  $evm.root['ae_reason'] = msg
+  $evm.log(:error, msg)
+  exit MIQ_OK
+end
+
+def yaml_data(task, option)
+  task.get_option(option).nil? ? nil : YAML.load(task.get_option(option))
+end
+
+# Creates provision requests based on the givin parameters.
+#
+# @param task                     ServiceTemplateProvisionTask Task used to create the service that will own the VMs created by these provision request(s)
+# @param requester                User                         User requesting the new VMs
+# @param number_of_vms            Integer                      Number of VMs to provision
+# @param template_fields          Hash                         Hash describing the template to use.
+#                                                              Must contain :name and :guid fields.
+# @param dialog_options           Hash                         User set options via dialog
+# @param tags                     Hash                         Tags to set on the created VMs.
+#                                                              Default {}
+# @param custom_vm_fields         Hash                         Custom vm_fields to use when creating the provsion request(s)
+#                                                              Default {}
+# @param custom_additional_values Hash                         Custom additional_values (ws_values) to use when creating the provsion request(s)
+#                                                              Default {}
+# @param create_seperate_requests Hash                         True to create seperate requests for each VM.
+#                                                              False to create one request that will create all of the requested VM(s)
+#                                                              Default true
+#
+# @return Array all of the created requests
+def create_provision_requests(task, requester, number_of_vms, template_fields, dialog_options,
+                              tags = {}, custom_vm_fields = {}, custom_additional_values = {}, create_seperate_requests = true)
+  $evm.log(:info, "START: create_provision_requests")                        if @DEBUG
+  $evm.log(:info, "number_of_vms            => #{number_of_vms}")            if @DEBUG
+  $evm.log(:info, "template_fields          => #{template_fields}")          if @DEBUG
+  $evm.log(:info, "dialog_options           => #{dialog_options}")           if @DEBUG
+  $evm.log(:info, "tags                     => #{tags}")                     if @DEBUG
+  $evm.log(:info, "custom_additional_values => #{custom_additional_values}") if @DEBUG
+  $evm.log(:info, "custom_vm_fields         => #{custom_vm_fields}")         if @DEBUG
+  $evm.log(:info, "create_seperate_requests => #{create_seperate_requests}") if @DEBUG
+  
+  # determine number of vms to create and
+  # how many provisioning requests to create and
+  # how many VMs per provisioning request
+  if create_seperate_requests
+    number_of_requests        = number_of_vms
+    number_of_vms_per_request = 1
+  else
+    number_of_requests        = 1
+    number_of_vms_per_request = number_of_vms
+  end
+  
+  # === START: template_fields
+  template_fields[:request_type] = 'template'
+  # === END: template_fields
+
+  # === START: vm_fields
+  
+  # determine if the provisioning LAN is a distributed vswitch or not
+  $evm.log(:info, "template_fields[:provisioning_lan] => #{template_fields[:provisioning_lan]}") if @DEBUG
+  provisioning_lan_name = template_fields[:provisioning_lan]
+  provisioning_lan      = $evm.vmdb(:lan).find_by_name(provisioning_lan_name)
+  if !(provisioning_lan_name =~ /^dvs_/) && provisioning_lan && provisioning_lan.switch.shared
+    provisioning_lan_name = "dvs_#{provisioning_lan_name}"
+  end
+  $evm.log(:info, "provisioning_lan_name => #{provisioning_lan_name}") if @DEBUG
+  
+  vm_fields = {
+    :vlan => provisioning_lan_name
+  }
+  vm_fields.merge!(custom_vm_fields)
+  vm_fields.merge!(dialog_options)
+  
+  # override number of vms
+  vm_fields[:number_of_vms] = number_of_vms_per_request
+  
+  # ensure option values are of correct type
+  vm_fields[:vm_memory] = vm_fields[:vm_memory].to_s if !vm_fields[:vm_memory].nil?
+  # === END: vm_fields
+
+  # === START: requester
+  requester = {
+    :user_name        => requester.userid,     # need this otherwise requestor will always be 'admin'
+    :owner_email      => requester.email,
+    :owner_first_name => requester.first_name,
+    :owner_last_name  => requester.last_name
+  }
+  # === END: requester
+
+  # === START: additional_values (AKA: ws_values)
+  additional_values = {
+    :service_id => task.destination.id
+  }
+  additional_values.merge!(custom_additional_values)
+  additional_values.merge!(dialog_options)
+  
+  # override number of vms
+  additional_values[:number_of_vms] = number_of_vms_per_request
+  # === END: additional_values (AKA: ws_values)
+  
+  # Setup the parameters needed for request
+  build_request = {
+    :version           => '1.1',
+    :template_fields   => template_fields,
+    :vm_fields         => vm_fields,
+    :requester         => requester,
+    :tags              => tags,
+    :additional_values => additional_values,
+    :ems_custom_attrs  => {},
+    :miq_custom_attrs  => {}
+  }
+  
+  # Create the actual provision request(s)
+  $evm.log(:info, "Execute '#{number_of_requests}' create_provision_requests for '#{number_of_vms_per_request}' VMs each: #{build_request}")
+  requests = []
+  number_of_requests.times do |count|
+    requests << $evm.execute(
+      'create_provision_request', 
+      build_request[:version],
+      build_request[:template_fields].stringify_keys,
+      build_request[:vm_fields].stringify_keys, 
+      build_request[:requester].stringify_keys,
+      build_request[:tags].stringify_keys,
+      build_request[:additional_values].stringify_keys,
+      build_request[:ems_custom_attrs].stringify_keys,
+      build_request[:miq_custom_attrs].stringify_keys)
+  end
+  $evm.log(:info, "requests => #{requests}") if @DEBUG
+  
+  $evm.log(:info, "END: create_provision_requests") if @DEBUG
+  return requests
+end
+
+begin
+  dump_current() if @DEBUG
+  dump_root()    if @DEBUG
+  
+  # get options and tags
+  $evm.log(:info, "$evm.root['vmdb_object_type'] => '#{$evm.root['vmdb_object_type']}'.") if @DEBUG
+  case $evm.root['vmdb_object_type']
+  when 'service_template_provision_task'
+    task = $evm.root['service_template_provision_task']
+    dump_object("service_template_provision_task", task) if @DEBUG
+
+    dialog_options           = yaml_data(task, :parsed_dialog_options)
+    dialog_options           = dialog_options[0] if !dialog_options[0].nil?
+    dialog_tags              = yaml_data(task, :parsed_dialog_tags)
+    custom_vm_fields         = task.get_option(:custom_vm_fields)
+    custom_additional_values = task.get_option(:custom_additional_values)
+  else
+    error("Can not handle vmdb_object_type: #{$evm.root['vmdb_object_type']}")
+  end
+  $evm.log(:info, "dialog_options           => #{dialog_options}")           if @DEBUG
+  $evm.log(:info, "dialog_tags              => #{dialog_tags}")              if @DEBUG
+  $evm.log(:info, "custom_vm_fields         => #{custom_vm_fields}")         if @DEBUG
+  $evm.log(:info, "custom_additional_values => #{custom_additional_values}") if @DEBUG
+  
+  # determine requestor
+  user = $evm.root['user']
+  dump_object("Current User", user) if @DEBUG
+  
+  # get the templates
+  templates = YAML.load(dialog_options[:templates]) if dialog_options[:templates]
+  error("Selected templates must be specified")     if templates.blank?
+  $evm.log(:info, "templates => #{templates}")      if @DEBUG
+  
+  # get the number of VMs
+  number_of_vms = dialog_options[:number_of_vms] || custom_vm_fields[:number_of_vms] || custom_additional_values[:number_of_vms] || 1
+  $evm.log(:info, "umber_of_vms => #{number_of_vms}") if @DEBUG
+  
+  # Create new provision request(s) based on the number of requested VM(s) and the number of template(s)
+  new_provision_requests = []
+  base_vms_per_template = number_of_vms / templates.length
+  templates.each_with_index do |template_fields, index|
+    number_of_vms_for_this_template  = base_vms_per_template
+    number_of_vms_for_this_template += 1 if index < number_of_vms % templates.length
+    
+    new_provision_requests |= create_provision_requests(
+                                task,
+                                user,
+                                number_of_vms_for_this_template,
+                                template_fields,
+                                dialog_options,
+                                dialog_tags,
+                                custom_vm_fields,
+                                custom_additional_values)
+  end
+  
+  # set requests on task so service task can wait for them to finish later in state machine
+  provision_request_ids = task.get_option(:provision_request_ids) || {}
+  provision_request_ids = provision_request_ids.values
+  new_provision_requests.each do |provision_request|
+    provision_request_ids << provision_request.id
+  end
+  provision_request_ids_hash = {}
+  provision_request_ids.each_with_index { |id, index| provision_request_ids_hash[index] = id }
+  task.set_option(:provision_request_ids, provision_request_ids_hash)
+  $evm.log(:info, "task.get_option(:provision_request_ids) => #{task.get_option(:provision_request_ids)}") if @DEBUG
+end

--- a/Automate/RedHatConsulting_Utilities/Service/Provisioning/StateMachines/Methods.class/__methods__/create_provision_requests.yaml
+++ b/Automate/RedHatConsulting_Utilities/Service/Provisioning/StateMachines/Methods.class/__methods__/create_provision_requests.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: create_provision_requests
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/Automate/RedHatConsulting_Utilities/Service/Provisioning/StateMachines/Methods.class/__methods__/set_custom_provision_task_options.rb
+++ b/Automate/RedHatConsulting_Utilities/Service/Provisioning/StateMachines/Methods.class/__methods__/set_custom_provision_task_options.rb
@@ -1,0 +1,93 @@
+# IMPLEMENTORS: intended to be overwritten.
+#
+# Sets additional dialog options on the given serivce.
+#
+@DEBUG = false
+
+# IMPLEMENTORS: intended to be overwritten
+#
+# @param dialog_options Hash Dialog options set by user when creating the service.
+#
+# @return Hash of custom vm_fileds to set on any vm provisioning requests created for the service being created
+def get_custom_vm_fields(dialog_options)
+  custom_vm_fields = {
+  }
+  
+  return custom_vm_fields
+end
+
+# IMPLEMENTORS: intended to be overwritten
+#
+# @param dialog_options Hash Dialog options set by user when creating the service.
+#
+# @return Hash of custom custom additional_values (ws_values) to set on any vm provisioning requests created for the service being created
+def get_custom_additional_values(dialog_options)
+  custom_additional_values = {
+  }
+  
+  return custom_additional_values
+end
+
+# IMPLEMENTORS: do not modify
+def dump_object(object_string, object)
+  $evm.log("info", "Listing #{object_string} Attributes:") 
+  object.attributes.sort.each { |k, v| $evm.log("info", "\t#{k}: #{v}") }
+  $evm.log("info", "===========================================") 
+end
+
+# IMPLEMENTORS: do not modify
+def dump_current
+  $evm.log("info", "Listing Current Object Attributes:") 
+  $evm.current.attributes.sort.each { |k, v| $evm.log("info", "\t#{k}: #{v}") }
+  $evm.log("info", "===========================================") 
+end
+
+# IMPLEMENTORS: do not modify
+def dump_root
+  $evm.log("info", "Listing Root Object Attributes:") 
+  $evm.root.attributes.sort.each { |k, v| $evm.log("info", "\t#{k}: #{v}") }
+  $evm.log("info", "===========================================") 
+end
+
+# IMPLEMENTORS: do not modify
+def error(msg)
+  $evm.root['ae_result'] = 'error'
+  $evm.root['ae_reason'] = msg
+  $evm.log(:error, msg)
+  exit MIQ_OK
+end
+
+# IMPLEMENTORS: do not modify
+def yaml_data(task, option)
+  task.get_option(option).nil? ? nil : YAML.load(task.get_option(option))
+end
+
+# IMPLEMENTORS: do not modify
+begin
+  dump_current() if @DEBUG
+  dump_root()    if @DEBUG
+  
+  # get options and tags
+  $evm.log(:info, "$evm.root['vmdb_object_type'] => '#{$evm.root['vmdb_object_type']}'.") if @DEBUG
+  case $evm.root['vmdb_object_type']
+  when 'service_template_provision_task'
+    task = $evm.root['service_template_provision_task']
+    dump_object("service_template_provision_task", task) if @DEBUG
+
+    dialog_options = yaml_data(task, :parsed_dialog_options)
+    dialog_options = dialog_options[0] if !dialog_options[0].nil?
+  else
+    error("Can not handle vmdb_object_type: #{$evm.root['vmdb_object_type']}")
+  end
+  $evm.log(:info, "dialog_options => #{dialog_options}") if @DEBUG
+  
+  # get the custom options
+  custom_vm_fields         = get_custom_vm_fields(dialog_options)
+  custom_additional_values = get_custom_additional_values(dialog_options)
+  
+  # set the custom options on the task
+  task.set_option(:custom_vm_fields, custom_vm_fields)
+  task.set_option(:custom_additional_values, custom_additional_values)
+  $evm.log(:info, "Set :custom_vm_fields         => #{custom_vm_fields}")         if @DEBUG
+  $evm.log(:info, "Set :custom_additional_values => #{custom_additional_values}") if @DEBUG
+end

--- a/Automate/RedHatConsulting_Utilities/Service/Provisioning/StateMachines/Methods.class/__methods__/set_custom_provision_task_options.yaml
+++ b/Automate/RedHatConsulting_Utilities/Service/Provisioning/StateMachines/Methods.class/__methods__/set_custom_provision_task_options.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: set_custom_provision_task_options
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/Automate/RedHatConsulting_Utilities/Service/Provisioning/StateMachines/Methods.class/createprovisionrequests.yaml
+++ b/Automate/RedHatConsulting_Utilities/Service/Provisioning/StateMachines/Methods.class/createprovisionrequests.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CreateProvisionRequests
+    inherits: 
+    description: 
+  fields:
+  - execute:
+      value: create_provision_requests

--- a/Automate/RedHatConsulting_Utilities/Service/Provisioning/StateMachines/Methods.class/setcustomprovisiontaskoptions.yaml
+++ b/Automate/RedHatConsulting_Utilities/Service/Provisioning/StateMachines/Methods.class/setcustomprovisiontaskoptions.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: SetCustomProvisionTaskOptions
+    inherits: 
+    description: Entry point to set custom options on the provision task
+  fields:
+  - execute:
+      value: set_custom_provision_task_options

--- a/Automate/RedHatConsulting_Utilities/Service/Provisioning/StateMachines/ServiceProvision_Template.class/generic_catalogiteminitialization.yaml
+++ b/Automate/RedHatConsulting_Utilities/Service/Provisioning/StateMachines/ServiceProvision_Template.class/generic_catalogiteminitialization.yaml
@@ -1,0 +1,46 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: Generic_CatalogItemInitialization
+    inherits: 
+    description: 
+  fields:
+  - sequencer:
+      value: "/Service/Provisioning/StateMachines/Methods/GroupSequenceCheck"
+  - pre1:
+      value: "/Service/Provisioning/StateMachines/Methods/DialogParser"
+  - pre2:
+      value: "/Service/Provisioning/StateMachines/Methods/CatalogItemInitialization"
+      on_entry: update_serviceprovision_status(status => 'Catalog Item Initialization')
+      on_exit: update_serviceprovision_status(status => 'Catalog Item Initialized')
+      on_error: 'update_serviceprovision_status(status => ''Error During Catalog Item
+        Initialization: ${/#ae_reason}'')'
+  - pre3:
+      value: "/Service/Provisioning/StateMachines/Methods/SetCustomProvisionTaskOptions"
+      on_entry: update_serviceprovision_status(status => 'Setting Custom Provision
+        Task Options')
+      on_exit: update_serviceprovision_status(status => 'Finished Setting Custom Provision
+        Task Options')
+      on_error: 'update_serviceprovision_status(status => ''Error Setting Custom Provision
+        Task Options: ${/#ae_reason}'')'
+  - provision:
+      value: "/Service/Provisioning/StateMachines/Methods/CreateProvisionRequests"
+      on_entry: update_serviceprovision_status(status => 'Creating Provision Requests')
+      on_exit: update_serviceprovision_status(status => 'Finished Creating Provision
+        Requests')
+      on_error: 'update_serviceprovision_status(status => ''Error Creating Provision
+        Requests: ${/#ae_reason}'')'
+  - checkprovisioned:
+      on_exit: update_serviceprovision_status(status => 'Waiting for Provision Requests')
+      on_error: 'update_serviceprovision_status(status => ''Error Waiting for Provision
+        Requests: ${/#ae_reason}'')'
+  - post5:
+      value: "/Service/Provisioning/StateMachines/Methods/ProcessTelemetryData"
+      on_entry: update_serviceprovision_status(status => 'Processing Telemetry Data')
+      on_exit: update_serviceprovision_status(status => 'Finished Processing Telemetry
+        Data')
+      on_error: 'update_serviceprovision_status(status => ''Error Processing Telemetry
+        Data: ${/#ae_reason}'')'

--- a/Automate/RedHatConsulting_Utilities/System/DynamicDialogs.class/__methods__/get_tags.rb
+++ b/Automate/RedHatConsulting_Utilities/System/DynamicDialogs.class/__methods__/get_tags.rb
@@ -51,12 +51,14 @@ begin
     single_value   = classification.single_value
     multiselect    = $evm.inputs['multiselect']
     always_visible = $evm.inputs['always_visible']
+    sort_order     = $evm.inputs['sort_order']
     visible        = (single_value == !multiselect) || always_visible
     
-    $evm.log(:info, "single_value   => #{single_value}") if @DEBUG
-    $evm.log(:info, "multiselect    => #{multiselect}")  if @DEBUG
-    $evm.log(:info, "always_visible => #{always_visible}")  if @DEBUG
-    $evm.log(:info, "visibile       => #{visible}")      if @DEBUG
+    $evm.log(:info, "single_value   => #{single_value}")   if @DEBUG
+    $evm.log(:info, "multiselect    => #{multiselect}")    if @DEBUG
+    $evm.log(:info, "always_visible => #{always_visible}") if @DEBUG
+    $evm.log(:info, "visibile       => #{visible}")        if @DEBUG
+    $evm.log(:info, "sort_order     => #{sort_order}")     if @DEBUG
   
     # determine tags to display
     if !visible || tag_category.nil? || tag_category.length.zero?
@@ -72,7 +74,7 @@ begin
   # create dialog element
   dialog_field = $evm.object
   dialog_field["sort_by"]    = "value"
-  dialog_field["sort_order"] = "ascending"
+  dialog_field["sort_order"] = sort_order
   dialog_field["data_type"]  = "string"
   dialog_field["visible"]    = visible
   dialog_field["values"]     = tags

--- a/Automate/RedHatConsulting_Utilities/System/DynamicDialogs.class/__methods__/get_tags.yaml
+++ b/Automate/RedHatConsulting_Utilities/System/DynamicDialogs.class/__methods__/get_tags.yaml
@@ -70,3 +70,23 @@ object:
       on_error: 
       max_retries: 
       max_time: 
+  - field:
+      aetype: 
+      name: sort_order
+      display_name: 
+      datatype: 
+      priority: 4
+      owner: 
+      default_value: ascending
+      substitute: false
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/Automate/RedHatConsulting_Utilities/System/DynamicDialogs.class/get_os_tags.yaml
+++ b/Automate/RedHatConsulting_Utilities/System/DynamicDialogs.class/get_os_tags.yaml
@@ -10,4 +10,4 @@ object:
   fields:
   - execute:
       value: get_tags(tag_category => 'os', multiselect => 'false', always_visible
-        => 'true')
+        => 'true', sort_order => 'descending')


### PR DESCRIPTION
This PR modifies get_templates_based_on_selected_os_and_location.rb to also generate a list of appropriate destination subnets, which are passed to a separate dialog in the Infoblox domain that displays them with more description of each lan.