### PR TITLE
Add .inspect to dump_thing method used by dump_root etc.

### DIFF
--- a/Automate/RedHatConsulting_Utilities/StdLib/Core.class/__methods__/core.rb
+++ b/Automate/RedHatConsulting_Utilities/StdLib/Core.class/__methods__/core.rb
@@ -18,7 +18,7 @@ module RedHatConsulting_Utilities
       def dump_thing(thing)
         log(:info, "Begin @handle.#{thing}.attributes")
         @handle.send(thing).attributes.sort.each { |k, v|
-          log(:info, "\t Attribute: #{k} = #{v}")
+          log(:info, "\t Attribute: #{k} = #{v.inspect}")
         }
         log(:info, "End @handle.#{thing}.attributes")
         log(:info, "")


### PR DESCRIPTION
This enables you to tell the data type (string vs. integer vs. boolean etc.) and to see the entire object.