### PR TITLE
Set and use 'destination_ip_address' var correctly

### DIFF
--- a/Automate/RedHatConsulting_Utilities/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/add_host_to_inventory.rb
+++ b/Automate/RedHatConsulting_Utilities/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/add_host_to_inventory.rb
@@ -29,9 +29,9 @@ module AutomationManagement
               log(:info, "Unable to determine VM IP address for Ansible Tower Inventory - no IP Addresses associated with VM.")
               return nil
             end
-            acquired_ip_address = get_param(:acquired_ip_address)
-            log(:info, "Aquired IP Address => #{acquired_ip_address}" )
-            ip_address = vm.ipaddresses.include?(acquired_ip_address) ?  acquired_ip_address : vm.ipaddresses.first
+            destination_ip = get_param(:destination_ip_address)
+            log(:info, "Host Destination IP Address => #{destination_ip}" )
+            ip_address = vm.ipaddresses.include?(destination_ip) ? destination_ip : vm.ipaddresses.first
             log(:info, "Discovered IP Address for Ansible Tower Inventory => #{ip_address}" )
             return ip_address
           end

--- a/Automate/RedHatConsulting_Utilities/Infrastructure/Network/Operations/Methods.class/__methods__/acquire_ip_address.rb
+++ b/Automate/RedHatConsulting_Utilities/Infrastructure/Network/Operations/Methods.class/__methods__/acquire_ip_address.rb
@@ -227,5 +227,10 @@ begin
   # set the acquired IP
   $evm.object['acquired_ip_address'] = acquired_ip_address
   $evm.set_state_var(:acquired_ip_address, acquired_ip_address)
+
+  # set destination IP address to acquired IP address
+  $evm.object['destination_ip_address'] = acquired_ip_address
+  $evm.set_state_var(:destination_ip_address, acquired_ip_address)
+
   $evm.log(:info, "$evm.object['acquired_ip_address'] => #{$evm.object['acquired_ip_address']}") if @DEBUG
 end

--- a/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/wait_for_vm_ip_addresses.rb
+++ b/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/wait_for_vm_ip_addresses.rb
@@ -21,7 +21,7 @@ module RedHatConsulting_Utilities
               error("vm parameter not found") if vm.blank?
 
               # check to see if there is an expected destination ip
-              expected_ip = options[:destination_ip] || get_param(:destination_ip)
+              expected_ip = options[:destination_ip_address] || get_param(:destination_ip_address)
 
               # ensure VM IP addresses are set
               if vm.ipaddresses.nil? || vm.ipaddresses.empty?


### PR DESCRIPTION
`Automate/RedHatConsulting_Utilities/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/add_host_to_inventory.rb`
+ use 'destination_ip_address' instead of 'acquired_ip_address'

`Automate/RedHatConsulting_Utilities/Infrastructure/Network/Operations/Methods.class/__methods__/acquire_ip_address.rb`
+ use 'destination_ip_address' instead of 'destination_ip'

`Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/wait_for_vm_ip_addresses.rb`
+ set 'destination_ip_address' as a state var
+ this enables the variable to be used if a retry is triggered in the state machine
+ collecting it during a step may result it the variable being unable to be accessed later if there is a retry