### PR TITLE
Update message from 'create' to "*" for attributes in placement instances

### DIFF
--- a/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/Placement.class/__class__.yaml
+++ b/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/Placement.class/__class__.yaml
@@ -100,7 +100,7 @@ object:
       owner: 
       default_value: 
       substitute: true
-      message: create
+      message: "*"
       visibility: 
       collect: 
       scope: 
@@ -120,7 +120,7 @@ object:
       owner: 
       default_value: 
       substitute: true
-      message: create
+      message: "*"
       visibility: 
       collect: 
       scope: 


### PR DESCRIPTION
Need to update message to '*' for attributes, since the default instance will always be invoked with a message of the provider name.
This means that the attributes will never be initialized with the default of 'create'