### PR TITLE
Update code that displays networks in dialogs

### DIFF
--- a/Automate/RedHatConsulting_Utilities/Infrastructure/Network/Configuration.class/__class__.yaml
+++ b/Automate/RedHatConsulting_Utilities/Infrastructure/Network/Configuration.class/__class__.yaml
@@ -112,3 +112,23 @@ object:
       on_error: 
       max_retries: 
       max_time: 
+  - field:
+      aetype: attribute
+      name: display_in_dialogs
+      display_name: 
+      datatype: boolean
+      priority: 6
+      owner: 
+      default_value: 'true'
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/Automate/RedHatConsulting_Utilities/Service/Provisioning/DynamicDialogs.class/__methods__/get_networks.rb
+++ b/Automate/RedHatConsulting_Utilities/Service/Provisioning/DynamicDialogs.class/__methods__/get_networks.rb
@@ -76,12 +76,14 @@ end
 
 # Get all of the network configuration instances.
 #
-# @return Array of all of the network configuration instances
+# @return Array of all of the network configuration instances enabled for dialogs
 NETWORK_CONFIGURATION_URI = 'Infrastructure/Network/Configuration'.freeze
 def get_network_configurations()
-  network_instances = $evm.vmdb("MiqAeDomain").all.collect { |domain| $evm.instance_find("/#{domain.name}/#{NETWORK_CONFIGURATION_URI}/*") }
-  network_instances = Hash[*network_instances.collect{|h| h.to_a}.flatten]
-  
+  network_instances = $evm.vmdb("MiqAeDomain").all.collect { |domain| $evm.instance_find("/#{domain.name}/#{NETWORK_CONFIGURATION_URI}/*") if domain.enabled}
+  network_instances = Hash[*network_instances.collect{|h| h.to_a}.flatten.uniq]
+  # remove network instances that should not be displayed based on network config
+  network_instances.delete_if { |pattern, cfg| cfg['display_in_dialogs'].to_s == "false" }
+  $evm.log(:info, "Network Instances to Display => #{network_instances}" ) if @DEBUG
   return network_instances
 end
 


### PR DESCRIPTION
* Add option to network configuration class
  to not display network in dialog
  * This is useful if you need to have
    network configurations for the full net name
    as well as part of the network name
    * custer_vlan_1 and vlan_1
* Ignore Network configurations in disabled domains
* Override Network configs in domain order