### PR TITLE
Update resize_disk.rb

### DIFF
--- a/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/resize_disk.rb
+++ b/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/resize_disk.rb
@@ -64,11 +64,11 @@ def resizeDisk(vm, disk_number, new_disk_size_in_kb)
       currentDiskIndex = 0
       devices.each do | dev |
         next if dev.xsiType != "VirtualDisk"
-        if diskIndex == currentDiskIndex
+        unit = dev["unitNumber"].to_i
+        if diskIndex == unit
           matchedDev = dev
           break
         end
-        currentDiskIndex += 1
       end
       raise "resize_disk: disk #{diskIndex} not found" unless matchedDev
       $log.info("resize_disk: resizing using matched device at #{diskIndex}")
@@ -146,7 +146,7 @@ begin
         $evm.log(:warn, "Requested disk size is: #{disk_size_kb} KiB which is smaller than existing size of #{current_disk_kb} KiB. Shrinking unsupported")
         exit MIQ_WARN
       else
-        disk_number -= 1 # Subtract 1 from the disk_number since VMware starts at 0 and CFME start at 1
+        #disk_number -= 1 # Subtract 1 from the disk_number since VMware starts at 0 and CFME start at 1
         resizeDisk(vm, disk_number, disk_size_kb)
       end
     rescue => e


### PR DESCRIPTION
Its possible using disk number to resize the incorrect disk if multiple remove and add operations are completed on a virtual machine. Using "UnitNumber" instead stops this mix up from occurring.

To pass the unit number from the dialog you can use the below code, which also provides the customer with a nice drop down choice.

#Get the  number of disks to loop through
i = 0
num = vm.num_disks

while i < num do
  disk_num = i
  
  if vm.hardware.disks[disk_num].device_type == "floppy"
    #i += 1
  else
    disk_location = vm.hardware.disks[disk_num].location
    disk_name = vm.hardware.disks[disk_num].filename.partition("]").last
    disk_name = disk_name.partition("/").last
    disk_size = vm.hardware.disks[disk_num].size/1024/1024/1024
    disk_type = vm.hardware.disks[disk_num].disk_type
    
    #This strips out the "0:" for the scsi device, leaving just the unit number to pass.
    unit_number = disk_location.partition(":").last
    values_hash[unit_number] = "Disk: #{disk_location}, #{disk_name}, Disk Size: #{disk_size}GB, Type: #{disk_type}"
  end
  i += 1
end