### PR TITLE
Removing list of memory values from provisioning Dialogs

### DIFF
--- a/provision_dialogs/miq_provision_redhat_dialogs_template_no_required_fields.yaml
+++ b/provision_dialogs/miq_provision_redhat_dialogs_template_no_required_fields.yaml
@@ -480,14 +480,6 @@
           :default: 1
           :data_type: :integer
         :vm_memory:
-          :values:
-            '1024': '1024'
-            '2048': '2048'
-            '4096': '4096'
-            '8192': '8192'
-            '12288': '12288'
-            '16384': '16384'
-            '32768': '32768'
           :description: Memory (MB)
           :required: false
           :display: :edit

--- a/provision_dialogs/miq_provision_vmware_dialogs_template_no_required_fields.yaml
+++ b/provision_dialogs/miq_provision_vmware_dialogs_template_no_required_fields.yaml
@@ -726,14 +726,6 @@
           :display: :edit
           :data_type: :integer
         :vm_memory:
-          :values:
-            '1024': '1024'
-            '2048': '2048'
-            '4096': '4096'
-            '8192': '8192'
-            '12288': '12288'
-            '16384': '16384'
-            '32768': '32768'
           :description: Memory (MB)
           :required: false
           :display: :edit


### PR DESCRIPTION
This allows any values from the service dialog to be used.
Before, could only use those that were in the provisioning dialog.
i.e 5GB would be rejected, because not in list, and default of 1G would
be used. 4GB would be accepted, because it is in the list.